### PR TITLE
Adding link to Sysmon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sysmon For Linux build and install instructions
 
+This project contains the code for build and installing [Sysmon](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon) on Linux.
+
 ## Dependencies
 For Ubuntu:
 ```


### PR DESCRIPTION
This PR aims to close #10.

Proposed solution simply adds a pointer to the "official" web page of the Windows version of Sysmon.