### PR TITLE
Update Correct command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ sudo tail -f /var/log/syslog
 ```
 or more human-readable
 ```
-sudo tail -f /var/log/syslog | /opt/sysmon/sysmonLogView
+sudo tail -f /var/log/syslog | sudo /opt/sysmon/sysmonLogView
 ```
 
 SysmonLogView has options to filter the output to make it easy to identify

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For Ubuntu:
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb https://download.mono-project.com/repo/ubuntu vs-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-vs.list
 sudo apt update
-sudo apt install build-essential gcc g++ make cmake libelf-dev llvm clang libxml2 libxml2-dev libzstd1 git libgtest-dev apt-transport-https dirmngr monodevelop googletest google-mock libjson-glib-dev
+sudo apt -y install build-essential gcc g++ make cmake libelf-dev llvm clang libxml2 libxml2-dev libzstd1 git libgtest-dev apt-transport-https dirmngr monodevelop googletest google-mock libjson-glib-dev
 cd /usr/src/googletest
 sudo mkdir build
 sudo chown *user*:*group* build


### PR DESCRIPTION
Correction on readme page regarding CLI command for viewing syslog logs via `SysmonLogView `is required.

The current provided code mentions:

`sudo tail -f /var/log/syslog | /opt/sysmon/sysmonLogView`

But we will get the output using `sudo tail -f /var/log/syslog | sudo /opt/sysmon/sysmonLogView`

Hope this helps!