### PR TITLE
Use reference vars for iteration in sysmonLogView.cpp

### DIFF
--- a/sysmonLogView/sysmonLogView.cpp
+++ b/sysmonLogView/sysmonLogView.cpp
@@ -449,9 +449,9 @@ void processCmdline(int argc, char *argv[],
                 }
                 printf("\n");
                 printf("Event Id Fields:\n");
-                for (const auto it : *eventIdFields) {
+                for (const auto& it : *eventIdFields) {
                     printf("  %d (", it.first);
-                    for (const auto it2 : it.second) {
+                    for (const auto& it2 : it.second) {
                         printf("%s ", it2.c_str());
                     }
                     printf(")\n");
@@ -479,9 +479,9 @@ void processCmdline(int argc, char *argv[],
                     printf("-1\n");
                 }
                 printf("Filters:\n");
-                for (const auto it2 : *filters) {
+                for (const auto& it2 : *filters) {
                     printf("  %s:\n", it2.first.c_str());
-                    for (const auto it3 : it2.second) {
+                    for (const auto& it3 : it2.second) {
                         printf("    %s\n", it3.c_str());
                     }
                 }

--- a/test/linuxRules.cpp
+++ b/test/linuxRules.cpp
@@ -150,7 +150,7 @@ TEST( Rules, WideString )
         { "\xc2\x90\xf0\x92\x8d\x85 ", {0x0090, 0xd808, 0xdf45, ' ', 0}, 8, 5 }
     };
 
-    for( auto CONST test : WideStrings ) {
+    for( auto CONST& test : WideStrings ) {
         EXPECT_EQ( WideStrlen( test.str1 ), test.str1len );
         EXPECT_EQ( WideStrlen( test.str2 ), test.str2len );
         EXPECT_EQ( WideStrcmp( test.str1, test.str2 ) == 0, test.strEqual );
@@ -182,7 +182,7 @@ TEST( Rules, WideString )
         EXPECT_EQ( test.lower, WideTolower( test.upper ) );
     }
 
-    for( auto CONST conv : WideConv ) {
+    for( auto CONST& conv : WideConv ) {
         CHAR utf8[32];
         WCHAR utf16[32];
         EXPECT_EQ( UTF8toUTF16( NULL, conv.utf8str, 0 ), conv.utf16count );


### PR DESCRIPTION
The prior implementation declared a loop-local copy for each of the
iterators on filters & eventIdFields in processCmdLine. Issue #23
points out that this causes a compilation failure when -Werror -Wall
is used, because this introduces an inefficiency. This change makes
these all references, which saves the superfluous copies and makes
the code compile again.

Fixes #23