### PR TITLE
Add -fno-stack-protector to eBPF program compile line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,7 +510,7 @@ set(CLANG_INCLUDES
 # function to make ebpf programs
 function(build_ebpf ebpfsrc)
     add_custom_command(OUTPUT ${ebpfsrc}.o
-                       COMMAND "${CLANG}" -nostdinc -isystem `gcc -print-file-name=include` ${CLANG_INCLUDES} ${CLANG_DEFINES} -O2 ${CLANG_OPTIONS} -emit-llvm -c "${CMAKE_SOURCE_DIR}/ebpfKern/${ebpfsrc}.c" -o -| "${LLC}" -march=bpf -filetype=obj -o "${ebpfsrc}.o"
+                       COMMAND "${CLANG}" -nostdinc -isystem `gcc -print-file-name=include` ${CLANG_INCLUDES} ${CLANG_DEFINES} -O2 ${CLANG_OPTIONS} -emit-llvm -fno-stack-protector -c "${CMAKE_SOURCE_DIR}/ebpfKern/${ebpfsrc}.c" -o -| "${LLC}" -march=bpf -filetype=obj -o "${ebpfsrc}.o"
                        COMMENT "Building EBPF object ${ebpfsrc}.o"
                        DEPENDS ebpfKern/${ebpfsrc}.c ${EBPF_DEPENDS}
                        )

--- a/networkTracker.cpp
+++ b/networkTracker.cpp
@@ -866,7 +866,7 @@ extern "C" bool NetworkTrackerSeenAccept(NetworkTracker *n, bool IPv4, const BYT
         return false;
     }
 
-    BYTE empty[16];
+    BYTE empty[16] = {0};
     AddrAndPort d(empty, IPv4, 0);
 
     if (n->SeenAccept(AddrAndPort(sourceAddr, IPv4, sourcePort), &d)) {


### PR DESCRIPTION
When compiling with this feature enabled for the project, we don't want it to be enabled on the stand-alone ebpf programs, because they don't have access to the C runtime bits needed to be linked in to support this (as, ostensibly, the kernel would implement its own facilities for this). Add `-fno-stack-protector` to the eBPF program compilation *only* so that it always turns the feature off when building the eBPF programlets.

Additionally, this PR contains a stylistic change to pre-initialize `empty` to zeroes in `NetworkTrackerSeenAccept(...)`, which silences a compiler warning about potential use of a value prior to initialization.