### PR TITLE
WSL2 build & unit testing support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,7 +365,7 @@ add_custom_command(OUTPUT yoursleep
 # automatically generate sources from manifest.xml and manifest.tt
 #
 add_custom_command(OUTPUT sysmonevents.h.utf16
-                   COMMAND "${TEXTTRANSFORM}" "${SYSMON_COMMON_SOURCE_DIR}/manifest.tt" -out sysmonevents.h.utf16 -a '!!type!header'
+                   COMMAND "mono" "${TEXTTRANSFORM}" "${SYSMON_COMMON_SOURCE_DIR}/manifest.tt" -out sysmonevents.h.utf16 -a '!!type!header'
                    COMMENT "Extracting sysmonevents.h.utf16"
                    DEPENDS "${SYSMON_COMMON_SOURCE_DIR}/manifest.tt"
                    )
@@ -377,7 +377,7 @@ add_custom_command(OUTPUT sysmonevents.h
                    )
 
 add_custom_command(OUTPUT sysmonmsg.mc.utf16
-                   COMMAND "${TEXTTRANSFORM}" "${SYSMON_COMMON_SOURCE_DIR}/manifest.tt" -out sysmonmsg.mc.utf16 -a '!!version!internal' -a '!!type!mc'
+                   COMMAND "mono" "${TEXTTRANSFORM}" "${SYSMON_COMMON_SOURCE_DIR}/manifest.tt" -out sysmonmsg.mc.utf16 -a '!!version!internal' -a '!!type!mc'
                    COMMENT "Extracting sysmonmsg.mc.utf16"
                    DEPENDS "${SYSMON_COMMON_SOURCE_DIR}/manifest.tt"
                    )
@@ -395,7 +395,7 @@ add_custom_command(OUTPUT sysmonmsg.h
                    )
 
 add_custom_command(OUTPUT sysmonmsgop.man.utf16
-                   COMMAND "${TEXTTRANSFORM}" "${SYSMON_COMMON_SOURCE_DIR}/manifest.tt" -out sysmonmsgop.man.utf16 -a '!!version!internal' -a '!!type!man'
+                   COMMAND "mono" "${TEXTTRANSFORM}" "${SYSMON_COMMON_SOURCE_DIR}/manifest.tt" -out sysmonmsgop.man.utf16 -a '!!version!internal' -a '!!type!man'
                    COMMENT "Extracting sysmonmsgop.man.utf16"
                    DEPENDS "${SYSMON_COMMON_SOURCE_DIR}/manifest.tt"
                    )


### PR DESCRIPTION
Minor changes to allow build & unit testing on WSL2:

- Use mono explicitly on TextTransform commands
- Adapt unit testing to work if CONFIG_AUDIT is not set (no sessionid).