### PR TITLE
Fix: Missing ProcessCreate m_AuthenticationId CO-RE compilation flag

### DIFF
--- a/ebpfKern/sysmonProcCreate.c
+++ b/ebpfKern/sysmonProcCreate.c
@@ -153,7 +153,11 @@ static inline char* set_ProcCreate_info(
     }
 
     // get the creds
+#ifdef EBPF_CO_RE
+    cred = BPF_CORE_READ((struct task_struct *)task, cred);
+#else
     cred = (const void *)derefPtr(task, config->offsets.cred);
+#endif
     if (cred) {
 #ifdef EBPF_CO_RE
         event->m_AuthenticationId.LowPart = (DWORD) BPF_CORE_READ((struct task_struct *)task, cred, uid.val);


### PR DESCRIPTION
The lack of `m_AuthenticationId` CO-RE compilation flag in [ebpfKern/sysmonProcCreate.c#L156](https://github.com/Sysinternals/SysmonForLinux/blob/da0f1954cba32128d580454d98c046e99c7a1c22/ebpfKern/sysmonProcCreate.c#L156) leads to missing ProcessCreate events user field.