### PR TITLE
Feature: Add image hash support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -19,7 +19,7 @@ If you installed SysinternalsEBPF via make install, you may need to add /usr/loc
 ```
 sudo apt update
 dotnet tool install --global dotnet-t4 --version 2.3.1
-sudo apt -y install build-essential gcc g++ make cmake libelf-dev llvm clang libxml2 libxml2-dev libzstd1 git libgtest-dev apt-transport-https dirmngr googletest google-mock libgmock-dev libjson-glib-dev libc6-dev-i386
+sudo apt -y install build-essential gcc g++ make cmake libelf-dev llvm clang libxml2 libxml2-dev libzstd1 git libgtest-dev apt-transport-https dirmngr googletest google-mock libgmock-dev libjson-glib-dev libc6-dev-i386 libssl-dev
 ```
 
 ### Rocky 9
@@ -30,7 +30,7 @@ sudo dnf install epel-release
 
 sudo dnf update
 dotnet tool install --global dotnet-t4 --version 2.3.1
-sudo yum install gcc gcc-c++ make cmake llvm clang elfutils-libelf-devel rpm-build json-glib-devel python3 libxml2-devel gtest-devel gmock gmock-devel glibc-devel.i686
+sudo yum install gcc gcc-c++ make cmake llvm clang elfutils-libelf-devel rpm-build json-glib-devel python3 libxml2-devel gtest-devel gmock gmock-devel glibc-devel.i686 openssl-devel
 ```
 
 ### Rocky 8
@@ -41,7 +41,7 @@ sudo dnf config-manager --set-enabled powertools
 
 sudo dnf update
 dotnet tool install --global dotnet-t4 --version 2.3.1
-sudo yum install gcc gcc-c++ make cmake llvm clang elfutils-libelf-devel rpm-build json-glib-devel python3 libxml2-devel gtest-devel gmock gmock-devel glibc-devel.i686
+sudo yum install gcc gcc-c++ make cmake llvm clang elfutils-libelf-devel rpm-build json-glib-devel python3 libxml2-devel gtest-devel gmock gmock-devel glibc-devel.i686 openssl-devel
 ```
 
 ### Debian 11
@@ -51,7 +51,7 @@ sudo dpkg -i packages-microsoft-prod.deb
 rm packages-microsoft-prod.deb
 sudo apt update
 dotnet tool install --global dotnet-t4 --version 2.3.1
-sudo apt -y install build-essential gcc g++ make cmake libelf-dev llvm clang libzstd1 git libjson-glib-dev libxml2 libxml2-dev googletest google-mock libgmock-dev libc6-dev-i386
+sudo apt -y install build-essential gcc g++ make cmake libelf-dev llvm clang libzstd1 git libjson-glib-dev libxml2 libxml2-dev googletest google-mock libgmock-dev libc6-dev-i386 libssl-dev
 ```
 
 ## Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ set(CMAKE_CXX_FLAGS "-std=gnu++17")
 find_package(LibXml2 2.0.0 REQUIRED)
 
 #
+# rely on openssl having been installed
+#
+find_package(OpenSSL REQUIRED)
+
+#
 # source directories
 #
 if(SYSMON_ADO)
@@ -329,7 +334,7 @@ set(EBPF_DEPENDS
 #
 # link sysmon
 #
-target_link_libraries(sysmon sysinternalsEBPF "${LIBXML2_LIBRARIES}" pthread)
+target_link_libraries(sysmon sysinternalsEBPF "${LIBXML2_LIBRARIES}" pthread OpenSSL::Crypto)
 
 
 #
@@ -398,7 +403,7 @@ add_executable(sysmonUnitTests
                "${PROJECT_BINARY_DIR}/yoursleep"
                )
 
-target_link_libraries(sysmonUnitTests "${LIBXML2_LIBRARIES}" ${GTEST_LIBRARIES} pthread)
+target_link_libraries(sysmonUnitTests "${LIBXML2_LIBRARIES}" ${GTEST_LIBRARIES} pthread OpenSSL::Crypto)
 target_include_directories(sysmonUnitTests PUBLIC
                            "${CMAKE_SOURCE_DIR}"
                            "${SYSMON_COMMON_SOURCE_DIR}"

--- a/linuxHelpers.cpp
+++ b/linuxHelpers.cpp
@@ -33,6 +33,7 @@
 #include <sys/stat.h>
 #include <pthread.h>
 #include <sys/syscall.h>
+#include <openssl/evp.h>
 
 //--------------------------------------------------------------------
 //
@@ -852,6 +853,128 @@ VOID LargeIntegerToSystemTimeString(
 
         snprintf( s, sLen, "Incorrect filetime: 0x%" PRIx64,
                      timestamp->QuadPart );
+    }
+}
+
+//--------------------------------------------------------------------
+//
+// LinuxGetFileHash
+//
+// Calculates image hash.
+//
+//--------------------------------------------------------------------
+void LinuxGetFileHash(PTCHAR imagePath, char *stringBuffer, size_t stringBufferSize)
+{
+    unsigned int        hashType;
+    unsigned char       tmpReadBuffer[4096] = {};
+    unsigned char       tmpHashBuffer[ALGO_MAX][256] = {};
+    unsigned char       tmpHashPrefixBuffer[16] = {};
+    unsigned char       tmpStringBuffer[256] = {};
+    char                hashSeparator[] = ",";
+    char                hashPrefix[3][8] = {"SHA1=", "MD5=", "SHA256="};
+    unsigned int        hashSize[ALGO_MAX];
+    unsigned int        hashFlag[ALGO_MAX] = {};
+    size_t              n;
+    FILE                *filePtr;
+    EVP_MD_CTX          *sha1_ctx, *md5_ctx, *sha256_ctx;	
+
+    // Get configured hash flag
+    if(OPT_SET( HashAlgorithms )){
+        hashType = *((unsigned int *)OPT_VALUE( HashAlgorithms ));
+    }
+    else{
+        hashType = ALGO_SHA256;
+    }
+
+    // Allocate digests context
+    sha1_ctx    = EVP_MD_CTX_new();
+    md5_ctx     = EVP_MD_CTX_new();
+    sha256_ctx  = EVP_MD_CTX_new();
+    if ( !sha1_ctx || !md5_ctx || !sha256_ctx ) return;
+
+    EVP_DigestInit(sha1_ctx  , EVP_sha1());
+    EVP_DigestInit(md5_ctx   , EVP_md5());
+    EVP_DigestInit(sha256_ctx, EVP_sha256());
+
+    hashFlag[ALGO_SHA1] = (((hashType>>(ALGO_SHA1-1))&1) && (hashType & ALGO_MULTIPLE)) || (hashType == ALGO_SHA1);
+    hashFlag[ALGO_MD5] = (((hashType>>(ALGO_MD5-1))&1) && (hashType & ALGO_MULTIPLE)) || (hashType == ALGO_MD5);
+    hashFlag[ALGO_SHA256] = (((hashType>>(ALGO_SHA256-1))&1) && (hashType & ALGO_MULTIPLE)) || (hashType == ALGO_SHA256);
+
+    filePtr = fopen(imagePath, "rb");
+    if( !filePtr ) return;
+
+    // Read and hash image
+    while((n = fread(tmpReadBuffer, 1, sizeof(tmpReadBuffer), filePtr))){
+
+        if( hashFlag[ALGO_SHA1] ){
+            if (!EVP_DigestUpdate(sha1_ctx, tmpReadBuffer, n)){
+                fclose(filePtr);
+                return;
+            }
+            if ( !(hashType & ALGO_MULTIPLE) ) continue;
+        }
+
+        if( hashFlag[ALGO_MD5] ){
+            if (!EVP_DigestUpdate(md5_ctx, tmpReadBuffer, n)){
+                fclose(filePtr);
+                return;
+            }
+            if ( !(hashType & ALGO_MULTIPLE) ) continue;
+        }
+
+        if( hashFlag[ALGO_SHA256] ){
+            if (!EVP_DigestUpdate(sha256_ctx, tmpReadBuffer, n)){
+                fclose(filePtr);
+                return;
+            }
+            if ( !(hashType & ALGO_MULTIPLE) ) continue;
+        }
+
+    }
+    fclose(filePtr);
+
+    // Retrieve digest and cleanup
+    EVP_DigestFinal(sha1_ctx  , tmpHashBuffer[ALGO_SHA1]  , &hashSize[ALGO_SHA1]);
+    EVP_DigestFinal(md5_ctx   , tmpHashBuffer[ALGO_MD5]   , &hashSize[ALGO_MD5]);
+    EVP_DigestFinal(sha256_ctx, tmpHashBuffer[ALGO_SHA256], &hashSize[ALGO_SHA256]);
+
+    memset(tmpStringBuffer, 0, sizeof(tmpStringBuffer));
+    memset(tmpHashPrefixBuffer, 0, sizeof(tmpHashPrefixBuffer));
+
+    for(unsigned int algo=0;algo<ALGO_MAX;algo++){
+        if( hashFlag[algo] ){
+
+            // Add seperator if multiple hashes
+            if( *tmpStringBuffer ){
+                memset(tmpStringBuffer, 0, sizeof(tmpStringBuffer));
+                memset(tmpHashPrefixBuffer, 0, sizeof(tmpHashPrefixBuffer));
+                
+                strcat((char *)tmpHashPrefixBuffer, hashSeparator);
+            }
+
+            // Add hash prefix "SHA1=", "MD5=" or "SHA256="
+            switch(algo){
+                case ALGO_SHA1:
+                    strcat((char *)tmpHashPrefixBuffer, hashPrefix[ALGO_SHA1-1]);
+                    break;
+                case ALGO_MD5:
+                    strcat((char *)tmpHashPrefixBuffer, hashPrefix[ALGO_MD5-1]);
+                    break;
+                case ALGO_SHA256:
+                    strcat((char *)tmpHashPrefixBuffer, hashPrefix[ALGO_SHA256-1]);
+                    break;
+            }
+
+            // Digest to hex
+            for(unsigned int i=0;i<hashSize[algo];i++){
+                snprintf((char *)tmpStringBuffer+i*2, sizeof(tmpStringBuffer), "%02x", tmpHashBuffer[algo][i]);
+            }
+
+            strcat(stringBuffer, (char *)tmpHashPrefixBuffer);
+            strcat(stringBuffer, (char *)tmpStringBuffer);
+
+            if( !(hashType & ALGO_MULTIPLE) ) return;
+        }
     }
 }
 

--- a/linuxHelpers.h
+++ b/linuxHelpers.h
@@ -54,6 +54,7 @@ unsigned int LargeTimeMilliseconds( CONST PLARGE_INTEGER timestamp );
 unsigned int LargeTimeNanoseconds( CONST PLARGE_INTEGER timestamp );
 VOID LinuxFileTimeToLargeInteger( PLARGE_INTEGER timestamp, const my_statx_timestamp *filetime );
 VOID LargeIntegerToSystemTimeString( char *s, size_t sLen, CONST PLARGE_INTEGER timestamp );
+void LinuxGetFileHash(PTCHAR imagePath, char *stringBuffer, size_t stringBufferSize);
 pid_t GetTid();
 
 #ifdef __cplusplus

--- a/linuxHelpers.h
+++ b/linuxHelpers.h
@@ -54,7 +54,7 @@ unsigned int LargeTimeMilliseconds( CONST PLARGE_INTEGER timestamp );
 unsigned int LargeTimeNanoseconds( CONST PLARGE_INTEGER timestamp );
 VOID LinuxFileTimeToLargeInteger( PLARGE_INTEGER timestamp, const my_statx_timestamp *filetime );
 VOID LargeIntegerToSystemTimeString( char *s, size_t sLen, CONST PLARGE_INTEGER timestamp );
-void LinuxGetFileHash(PTCHAR imagePath, char *stringBuffer, size_t stringBufferSize);
+void LinuxGetFileHash(uint32_t hashType, PTCHAR imagePath, char *stringBuffer, size_t stringBufferSize);
 pid_t GetTid();
 
 #ifdef __cplusplus

--- a/package/DEBIAN.in/control.in
+++ b/package/DEBIAN.in/control.in
@@ -3,6 +3,6 @@ Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
 Architecture: amd64
 Maintainer: Sysinternals <syssite@microsoft.com>
 Description: A system monitor based on eBPF, ported from Windows, that outputs events to Syslog
-Depends: libc6 (>= 2.14), libgcc1 (>= 1:3.0), libstdc++6 (>= 5), libxml2 (>= 2.7.4), sysinternalsebpf (>= 1.2.0)
+Depends: libc6 (>= 2.14), libgcc1 (>= 1:3.0), libstdc++6 (>= 5), libxml2 (>= 2.7.4), libssl-dev, sysinternalsebpf (>= 1.2.0)
 Installed-Size: 58934
 

--- a/sysmonforlinux.c
+++ b/sysmonforlinux.c
@@ -545,6 +545,78 @@ void processProcessAccess(CONST PSYSMON_EVENT_HEADER eventHdr)
 
 //--------------------------------------------------------------------
 //
+// processProcessCreate
+//
+// Handles process create events
+//
+//--------------------------------------------------------------------
+void processProcessCreate(CONST PSYSMON_EVENT_HEADER eventHdr)
+{
+    if(eventHdr == NULL) {
+        fprintf(stderr, "processFileCreate invalid params\n");
+        return;
+    }
+
+    char newData[65536];
+
+    PSYSMON_EVENT_HEADER newEventHdr = (PSYSMON_EVENT_HEADER)newData;
+    newEventHdr->m_FieldFiltered = 0;
+    newEventHdr->m_PreFiltered = 0;
+    newEventHdr->m_SequenceNumber = 0;
+    newEventHdr->m_SessionId = 0;
+    
+    PSYSMON_PROCESS_CREATE event = (PSYSMON_PROCESS_CREATE)&(eventHdr->m_EventBody);
+
+    newEventHdr->m_EventType = ProcessCreate;
+    PSYSMON_PROCESS_CREATE newEvent = &newEventHdr->m_EventBody.m_ProcessCreateEvent;
+    newEvent->m_ProcessId = event->m_ProcessId;
+    newEvent->m_ProcessObject = event->m_ProcessObject;
+    newEvent->m_ParentProcessObject = event->m_ParentProcessObject;
+    newEvent->m_ParentProcessId = event->m_ParentProcessId;
+    newEvent->m_AuditUserId = event->m_AuditUserId;
+    newEvent->m_SessionId = event->m_SessionId;
+    newEvent->m_AuthenticationId.LowPart = event->m_AuthenticationId.LowPart;
+    newEvent->m_AuthenticationId.HighPart = event->m_AuthenticationId.HighPart;
+    newEvent->m_ProcessKey = event->m_ProcessKey;
+    newEvent->m_CreateTime.QuadPart = event->m_CreateTime.QuadPart;
+    
+    if(OPT_SET( HashAlgorithms )){
+        newEvent->m_HashType = *((unsigned int *)OPT_VALUE( HashAlgorithms ));
+    }
+    else{
+        newEvent->m_HashType = 0;
+    }
+
+    memset(newEvent->m_Extensions, 0, sizeof(newEvent->m_Extensions));
+    const char *ptr = (char *)(event + 1);
+    char *newPtr = (char *)(newEvent + 1);
+
+    memcpy(newPtr, ptr, event->m_Extensions[PC_Sid]);
+    newEvent->m_Extensions[PC_Sid] = event->m_Extensions[PC_Sid];
+    ptr += event->m_Extensions[PC_Sid];
+    newPtr += event->m_Extensions[PC_Sid];
+    
+    memcpy(newPtr, ptr, event->m_Extensions[PC_ImagePath]);
+    newEvent->m_Extensions[PC_ImagePath] = event->m_Extensions[PC_ImagePath];
+    ptr += event->m_Extensions[PC_ImagePath];
+    newPtr += event->m_Extensions[PC_ImagePath];
+    
+    memcpy(newPtr, ptr, event->m_Extensions[PC_CommandLine]);
+    newEvent->m_Extensions[PC_CommandLine] = event->m_Extensions[PC_CommandLine];
+    ptr += event->m_Extensions[PC_CommandLine];
+    newPtr += event->m_Extensions[PC_CommandLine];
+    
+    memcpy(newPtr, ptr, event->m_Extensions[PC_CurrentDirectory]);
+    newEvent->m_Extensions[PC_CurrentDirectory] = event->m_Extensions[PC_CurrentDirectory];
+    newPtr += event->m_Extensions[PC_CurrentDirectory];
+
+    newEventHdr->m_EventSize = (uint32_t)((void *)newPtr - (void *)newEventHdr);
+
+    DispatchEvent(newEventHdr);
+}
+
+//--------------------------------------------------------------------
+//
 // handleEvent
 //
 // Receives the eBPF telemetry and sends it to DispatchEvent().
@@ -570,6 +642,9 @@ static void handleEvent(void *ctx, int cpu, void *data, uint32_t size)
             break;
         case ProcessAccess:
             processProcessAccess(eventHdr);
+            break;
+        case ProcessCreate:
+            processProcessCreate(eventHdr);
             break;
         case ProcessTerminate:
         {

--- a/sysmonforlinux.c
+++ b/sysmonforlinux.c
@@ -581,7 +581,8 @@ void processProcessCreate(CONST PSYSMON_EVENT_HEADER eventHdr)
     newEvent->m_CreateTime.QuadPart = event->m_CreateTime.QuadPart;
     
     if(OPT_SET( HashAlgorithms )){
-        newEvent->m_HashType = *((unsigned int *)OPT_VALUE( HashAlgorithms ));
+        unsigned int *hashTypePtr = OPT_VALUE( HashAlgorithms );
+        newEvent->m_HashType = *hashTypePtr;
     }
     else{
         newEvent->m_HashType = 0;

--- a/sysmonforlinux.c
+++ b/sysmonforlinux.c
@@ -647,12 +647,7 @@ void processFileDelete(CONST PSYSMON_EVENT_HEADER eventHdr)
     newEvent->m_Archived[0] = event->m_Archived[0];
     newEvent->m_TrackerId = event->m_TrackerId;
     
-    if(OPT_SET( HashAlgorithms )){
-        newEvent->m_HashType = *((unsigned int *)OPT_VALUE( HashAlgorithms ));
-    }
-    else{
-        newEvent->m_HashType = 0;
-    }
+    newEvent->m_HashType = 0xFF; // 0xFF will not be interpreted as any ALGO_*. Therefore, Hashes field will always be blank.
 
     memset(newEvent->m_Extensions, 0, sizeof(newEvent->m_Extensions));
     const char *ptr = (char *)(event + 1);


### PR DESCRIPTION
This pull request adds the feature to calculate an event image hash through a new `LinuxHelper` `LinuxGetFileHash`.

It allows to configure SHA1, MD5 and/or SHA256 through the HashAlgorithms configuration tag and depends on `OpenSSL::Crypto` (`libssl-dev`/`openssl-devel`). OpenSSL being here an easy solution, it's also possible to replace it by standard headers in case of any licensing difficulties.

As the `N_Hash` field is handled by `eventsCommon.cpp` in the SysmonCommon submodule, this pull request fully depends and is directly linked to [another PR on the SysmonCommon repository](https://github.com/Sysinternals/SysmonCommon/pull/8).