### PR TITLE
doc: fix key path for Debian 12

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,12 +36,8 @@ sudo apt-get install sysmonforlinux
 ## Debian 12
 #### 1. Register Microsoft key and feed
 ```sh
-wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft-prod.gpg
-sudo mv microsoft-prod.gpg /usr/share/keyrings/
-wget -q https://packages.microsoft.com/config/debian/12/prod.list
-sudo mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
-sudo chown root:root /usr/share/keyrings/microsoft-prod.gpg
-sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list
+wget -q https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
 ```
 
 #### 2. Install SysmonForLinux

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,11 +36,11 @@ sudo apt-get install sysmonforlinux
 ## Debian 12
 #### 1. Register Microsoft key and feed
 ```sh
-wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
-sudo mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
+wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft-prod.gpg
+sudo mv microsoft-prod.gpg /usr/share/keyrings/
 wget -q https://packages.microsoft.com/config/debian/12/prod.list
 sudo mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
-sudo chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
+sudo chown root:root /usr/share/keyrings/microsoft-prod.gpg
 sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list
 ```
 


### PR DESCRIPTION
This fixes the download path to be the one referenced by the repository list file.