### PR TITLE
Feature: Add restart configuration to service

### DIFF
--- a/sysmon.service
+++ b/sysmon.service
@@ -15,12 +15,16 @@
 [Unit]
 Description=Sysmon event logger
 After=syslog.service
+StartLimitBurst=5
+StartLimitIntervalSec=90
 
 [Service]
 Type=forking
 User=root
 WorkingDirectory=/opt/sysmon
 ExecStart=/opt/sysmon/sysmon -i /opt/sysmon/config.xml -service
+Restart=on-failure
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Issue

If Sysmon fails during runtime, it will not restart until the server reboots. This will severely impact log collection from the endpoint. The stopped service can be detected and restarted using external tools, or by modifying the systemd service file after installation, but this requires implementation in each new environment where SysmonForLinux is implemented.

### Suggested Solution

Add configuration to the systemd service definition to allow systemd to automatically attempt to restart the service in case of failure.

See #172