### PR TITLE
Linux kernel 6.6+ renames inode fields causing Sysmon to fail

### DIFF
--- a/ebpfKern/sysmonEBPF_common.h
+++ b/ebpfKern/sysmonEBPF_common.h
@@ -35,6 +35,7 @@
 
 #ifdef EBPF_CO_RE
 #include "vmlinux.h"
+#include "vmlinux_kern_diffs.h"
 #else
 #include <linux/version.h>
 #include <linux/bpf.h>

--- a/vmlinux.h
+++ b/vmlinux.h
@@ -3054,9 +3054,9 @@ struct inode {
 	};
 	dev_t i_rdev;
 	loff_t i_size;
-	struct timespec64 i_atime;
-	struct timespec64 i_mtime;
-	struct timespec64 i_ctime;
+	struct timespec64 __i_atime;
+	struct timespec64 __i_mtime;
+	struct timespec64 __i_ctime;
 	spinlock_t i_lock;
 	short unsigned int i_bytes;
 	u8 i_blkbits;

--- a/vmlinux_kern_diffs.h
+++ b/vmlinux_kern_diffs.h
@@ -1,0 +1,52 @@
+/*
+    SysmonForLinux
+
+    Copyright (c) Microsoft Corporation
+
+    All rights reserved.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+//====================================================================
+//
+// vmlinux_kern_diffs.h
+//
+// Contains type definitions that are kernel version dependent.
+// The type definitions are usually duplicates (although with only
+// the fields that are relevant). CO-RE has a special naming convention
+// to properly handle this. See "Handling incompatible field and type changes"
+// in:
+//
+// https://nakryiko.com/posts/bpf-core-reference-guide/#defining-own-co-re-relocatable-type-definitions
+//
+//====================================================================
+
+#ifndef __VMLINUX_KERN_DIFFS_H__
+#define __VMLINUX_KERN_DIFFS_H__
+
+#include <vmlinux.h>
+
+//
+// In kernel v6.6 inode i_ctime, i_atime and i_mtime field changed to __i_Xtime.
+//
+struct inode___pre_v66
+{
+    struct timespec64 i_atime;
+    struct timespec64 i_mtime;
+    struct timespec64 i_ctime;
+};
+
+#endif /* __VMLINUX_KERN_DIFFS_H__ */


### PR DESCRIPTION
Fixes issue #174 